### PR TITLE
Update display offset to 0 for KSGER v3

### DIFF
--- a/BOARDS/KSGER/[v3]/STM32F101/Core/Inc/board.h
+++ b/BOARDS/KSGER/[v3]/STM32F101/Core/Inc/board.h
@@ -23,7 +23,7 @@
 #define USE_RST                                               // Reset pin is used
 #define USE_DC                                                // DC pin is used
 //#define USE_CS                                              // CS pin is used
-#define OLED_OFFSET         2                                 // Display offset
+#define OLED_OFFSET         0                                 // Display offset
 
 /********************************
  *      PWM Settings        *


### PR DESCRIPTION
I don't know about anybody else, but the default offset for my KSGER v3.0 board is 0