### PR TITLE
Make languages be optional

### DIFF
--- a/Core/Inc/settings.h
+++ b/Core/Inc/settings.h
@@ -14,11 +14,35 @@
 
 #define SWSTRING          "SW: "__DATE__                            // Software version reported in settings screen
 #define SETTINGS_VERSION  18                                        // Change this if you change the settings/profile struct to prevent getting out of sync
-#define LANGUAGE_COUNT    5                                         // Number of languages
 #define NUM_PROFILES      3                                         // Number of profiles
 #define NUM_TIPS          40                                        // Number of tips for each profile
 #define TipCharSize       5                                         // String size for each tip name (Including null termination)
 #define _BLANK_TIP        "    "                                    // Empty tip name, 4 spaces. Defined here for quick updating if TipCharSize is modified.
+
+//#define USE_LANG_RUSSIAN
+//#define USE_LANG_SWEDISH
+//#define USE_LANG_GERMAN
+//#define USE_LANG_TURKISH
+
+// calculate the number of languages
+// use anonymous enum to export constant
+enum {
+	LANGUAGE_COUNT = (
+		1
+#ifdef USE_LANG_RUSSIAN
+		+ 1
+#endif
+#ifdef USE_LANG_SWEDISH
+		+ 1
+#endif
+#ifdef USE_LANG_GERMAN
+		+ 1
+#endif
+#ifdef USE_LANG_TURKISH
+		+ 1
+#endif
+	),
+};
 
 #ifndef PROFILE_VALUES
 
@@ -105,10 +129,18 @@ typedef enum{
   output_High,
 
   lang_english             = 0,
+#ifdef USE_LANG_RUSSIAN
   lang_russian             = 1,
+#endif
+#ifdef USE_LANG_SWEDISH
   lang_swedish             = 2,
+#endif
+#ifdef USE_LANG_GERMAN
   lang_german              = 3,
+#endif
+#ifdef USE_LANG_TURKISH
   lang_turkish             = 4,
+#endif
 
 
   dim_off                  = 0,

--- a/Drivers/graphics/gui/screens/gui_strings.c
+++ b/Drivers/graphics/gui/screens/gui_strings.c
@@ -189,6 +189,7 @@ const strings_t strings[LANGUAGE_COUNT] = {
       .errMode =     { "SLP", "RUN", "LAST" },
     },
 
+#ifdef USE_LANG_RUSSIAN
     [lang_russian] = {
       .boot_firstBoot = "Выберите",
       .boot_Profile = "Тип",
@@ -369,7 +370,9 @@ const strings_t strings[LANGUAGE_COUNT] = {
       .errMode =     { "ВЫКЛ", "ПУСК", "ПРЕД" },
 
     },
+#endif
 
+#ifdef USE_LANG_SWEDISH
     [lang_swedish] = {
       .boot_firstBoot = "Första Start!",
       .boot_Profile = "Profil",
@@ -548,7 +551,9 @@ const strings_t strings[LANGUAGE_COUNT] = {
       .dimMode =     { "AV", "SOV", "ALLA" },
       .errMode =     { "SOV", "KÖR", "FRG" },
     },
+#endif
 
+#ifdef USE_LANG_GERMAN
     [lang_german] = {
       .boot_firstBoot = "Erster Start",
       .boot_Profile = "Profile",
@@ -727,7 +732,9 @@ const strings_t strings[LANGUAGE_COUNT] = {
       .dimMode =     { "OFF", "SLP", "ALL" },
       .errMode =     { "SLP", "RUN", "LAST" },
     },
+#endif
 
+#ifdef USE_LANG_TURKISH
     [lang_turkish] = {
       .boot_firstBoot = "İlk Önyükleme!",
       .boot_Profile = "Profil",
@@ -906,6 +913,7 @@ const strings_t strings[LANGUAGE_COUNT] = {
       .dimMode =     { "KPLI", "UYKU", "TÜM" },
       .errMode =     { "UYKU", "ÇLS", "SON" },
     },
+#endif
 };
 
 
@@ -913,8 +921,17 @@ char * const tempUnit[2]              = { "\260C", "\260F" };
 char * const profileStr[NUM_PROFILES] = { "T12", "C245", "C210" };
 char * const Langs[LANGUAGE_COUNT]    = {
                                             [lang_english] = "EN",
+
+#ifdef USE_LANG_RUSSIAN
                                             [lang_russian] = "RU",
+#endif
+#ifdef USE_LANG_SWEDISH
                                             [lang_swedish] = "SWE",
+#endif
+#ifdef USE_LANG_GERMAN
                                             [lang_german]  = "GER",
+#endif
+#ifdef USE_LANG_TURKISH
                                             [lang_turkish] = "TR",
+#endif
                                         };


### PR DESCRIPTION
This commit helps to not include unwanted languages to reduce flash memory.
As tested, Flash usages decreased from 97% (121KB) to 64% (79KB).
